### PR TITLE
FIX Cohttp EOF read with Lwt_unix recv MSG_PEEK

### DIFF
--- a/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.ml
+++ b/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.ml
@@ -180,6 +180,9 @@ struct
 
   let callv ?ctx:_ _uri _reqs = Lwt.fail Cohttp_lwt_xhr_callv_not_implemented
 
+  let call_with_closefn ?ctx:_ ?headers:_ ?body:_ ?chunked:_ _meth _uri =
+    Lwt.fail Not_found
+
   (* ??? *)
 end
 

--- a/cohttp-lwt-unix/test/dune
+++ b/cohttp-lwt-unix/test/dune
@@ -36,6 +36,11 @@
  (name test_body)
  (libraries cohttp_lwt_unix_test cohttp-lwt-unix))
 
+(executable
+ (modules test_leak)
+ (name test_leak)
+ (libraries cohttp-lwt-unix))
+
 (rule
  (alias runtest)
  (package cohttp-lwt-unix)

--- a/cohttp-lwt-unix/test/test_leak.ml
+++ b/cohttp-lwt-unix/test/test_leak.ml
@@ -27,6 +27,7 @@ let start_server () =
       ~mode:(`TCP (`Port port))
       (Server.make
          ~conn_closed:(fun _ -> Format.printf "Cohttp connection closed\n%!")
+         ~sleep_fn:(fun () -> Lwt_unix.sleep 1.0)
          ~callback ())
   in
   Printf.printf "Server running on port %d\n%!" port;

--- a/cohttp-lwt-unix/test/test_leak.ml
+++ b/cohttp-lwt-unix/test/test_leak.ml
@@ -1,0 +1,35 @@
+open Lwt
+open Cohttp_lwt_unix
+
+let port = 8080
+
+let callback (_, con) req _body =
+  (* Record connection established *)
+  let con_string = Cohttp.Connection.to_string con in
+  Format.printf "Cohttp connection on %s@." con_string;
+  (* Match given endpoint *)
+  let uri = req |> Request.uri |> Uri.path in
+  match uri with
+  | "/sleep" ->
+      (* Continuous sleep *)
+      let rec get_busy () =
+        Lwt_unix.sleep 1.0 >>= fun () ->
+        Format.printf "I slept @.";
+        get_busy ()
+      in
+      get_busy ()
+  (* Unknown call *)
+  | _ -> Server.respond_string ~status:`Not_found ~body:"Not found" ()
+
+let start_server () =
+  let server =
+    Server.create
+      ~mode:(`TCP (`Port port))
+      (Server.make
+         ~conn_closed:(fun _ -> Format.printf "Cohttp connection closed\n%!")
+         ~callback ())
+  in
+  Printf.printf "Server running on port %d\n%!" port;
+  server
+
+let () = Lwt_main.run (start_server ())

--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -13,6 +13,19 @@ module type IO = sig
       which case it returns the error. *)
 
   val pp_error : Format.formatter -> error -> unit
+
+  val wait_eof_or_closed : conn -> ic -> (unit -> unit t) -> unit t
+  (** [wait_eof_or_closed conn ic sleep_fn] waits for an EOF or a Closed status
+      on the input channel [ic]. This function is designed to be used in
+      [Lwt.pick] to run concurrently with the request handling from the input
+      channel. [sleep_fn] is a function used to yield control periodically,
+      keeping the Cohttp platform independent. This function ensures that the
+      monitoring does not spin too quickly and uses CPU efficiently when the
+      input channel has read activity but the client is not reading it. The
+      function checks for EOF using [MSG_PEEK] on the input channel without
+      consuming data, thereby not disturbing the request handling. If the
+      connection is closed locally, Cohttp will stop waiting for EOF and will
+      wait the promise to be cancelled.*)
 end
 
 (** The [Net] module type defines how to connect to a remote node and close the
@@ -155,12 +168,27 @@ module type Server = sig
 
   val make_response_action :
     ?conn_closed:(conn -> unit) ->
+    ?sleep_fn:(unit -> unit Lwt.t) ->
     callback:(conn -> Cohttp.Request.t -> Body.t -> response_action Lwt.t) ->
     unit ->
     t
+  (** [make_response_action] creates a set of callbacks used by Cohttp Server.
+
+      - [callback] is called when a new connection is accepted by the server
+        socket.
+      - [conn_closed] if provided, will be called when the connection is closed,
+        e.g. when an EOF is received.
+      - [sleep_fn] if provided, will be used for periodic checks for EOF from
+        the client. If this callback is not provided, Cohttp will not detect and
+        notify the client about EOF received from the peer while the client is
+        handling the new connection. This can lead to a resource leak if the
+        [callback] is designed to never resolve. If the connection is closed
+        locally, Cohttp will stop waiting for EOF and will wait the promise to
+        be cancelled. *)
 
   val make_expert :
     ?conn_closed:(conn -> unit) ->
+    ?sleep_fn:(unit -> unit Lwt.t) ->
     callback:
       (conn ->
       Cohttp.Request.t ->
@@ -171,6 +199,7 @@ module type Server = sig
 
   val make :
     ?conn_closed:(conn -> unit) ->
+    ?sleep_fn:(unit -> unit Lwt.t) ->
     callback:
       (conn -> Cohttp.Request.t -> Body.t -> (Cohttp.Response.t * Body.t) Lwt.t) ->
     unit ->

--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -87,7 +87,21 @@ module type Client = sig
       (using [ocaml-tls]) or SSL (using [ocaml-ssl]), on [*:443] or on the
       specified port by the user. If neitehr [ocaml-tls] or [ocaml-ssl] are
       installed on the system, [cohttp]/[conduit] tries the usual ([*:80]) or
-      the specified port by the user in a non-secured way. *)
+      the specified port by the user in a non-secured way.
+
+      The function returns response and body. *)
+
+  val call_with_closefn :
+    ?ctx:ctx ->
+    ?headers:Cohttp.Header.t ->
+    ?body:Body.t ->
+    ?chunked:bool ->
+    Cohttp.Code.meth ->
+    Uri.t ->
+    ((Cohttp.Response.t * Body.t) Lwt.t * (unit -> unit)) Lwt.t
+  (** [call_with_closefn ?ctx ?headers ?body ?chunked meth uri] is the same as
+      [call] but returns response, body and [close_fn] which force releases the
+      connection. *)
 
   val head :
     ?ctx:ctx -> ?headers:Cohttp.Header.t -> Uri.t -> Cohttp.Response.t Lwt.t

--- a/cohttp-lwt/src/server.ml
+++ b/cohttp-lwt/src/server.ml
@@ -19,22 +19,23 @@ module Make (IO : S.IO) = struct
   type t = {
     callback : conn -> Cohttp.Request.t -> Body.t -> response_action Lwt.t;
     conn_closed : conn -> unit;
+    sleep_fn : (unit -> unit Lwt.t) option;
   }
 
-  let make_response_action ?(conn_closed = ignore) ~callback () =
-    { conn_closed; callback }
+  let make_response_action ?(conn_closed = ignore) ?sleep_fn ~callback () =
+    { conn_closed; callback; sleep_fn }
 
-  let make ?conn_closed ~callback () =
+  let make ?conn_closed ?sleep_fn ~callback () =
     let callback conn req body =
       callback conn req body >|= fun rsp -> `Response rsp
     in
-    make_response_action ?conn_closed ~callback ()
+    make_response_action ?conn_closed ?sleep_fn ~callback ()
 
-  let make_expert ?conn_closed ~callback () =
+  let make_expert ?conn_closed ?sleep_fn ~callback () =
     let callback conn req body =
       callback conn req body >|= fun rsp -> `Expert rsp
     in
-    make_response_action ?conn_closed ~callback ()
+    make_response_action ?conn_closed ?sleep_fn ~callback ()
 
   module Transfer_IO = Cohttp__Transfer_io.Make (IO)
 
@@ -111,7 +112,9 @@ module Make (IO : S.IO) = struct
                 `Response rsp))
       (fun () -> Body.drain_body body)
 
-  let handle_response ~keep_alive oc res body conn_closed handle_client =
+  type conn_action = Call_conn_closed | Call_conn_closed_and_drain of Body.t
+
+  let handle_response ~keep_alive oc res body _conn_closed handle_client =
     IO.catch (fun () ->
         let flush = Response.flush res in
         Response.write ~flush
@@ -119,24 +122,22 @@ module Make (IO : S.IO) = struct
           res oc)
     >>= function
     | Ok () ->
-        if keep_alive then handle_client oc
-        else
-          let () = conn_closed () in
-          Lwt.return_unit
+        if keep_alive then handle_client oc else Lwt.return Call_conn_closed
     | Error e ->
         Log.info (fun m -> m "IO error while writing body: %a" IO.pp_error e);
-        conn_closed ();
-        Body.drain_body body
+        Lwt.return (Call_conn_closed_and_drain body)
 
   let rec handle_client ic oc conn spec =
+    let _, conn_id = conn in
     Request.read ic >>= function
     | `Eof ->
-        spec.conn_closed conn;
-        Lwt.return_unit
+        Log.debug (fun m ->
+            m "Got EOF while handling client: %s"
+              (Cohttp.Connection.to_string conn_id));
+        Lwt.return Call_conn_closed
     | `Invalid data ->
         Log.err (fun m -> m "invalid input %s while handling client" data);
-        spec.conn_closed conn;
-        Lwt.return_unit
+        Lwt.return Call_conn_closed
     | `Ok req -> (
         let body = read_body ic req in
         handle_request spec.callback conn req body >>= function
@@ -152,9 +153,28 @@ module Make (IO : S.IO) = struct
   let callback spec io_id ic oc =
     let conn_id = Cohttp.Connection.create () in
     let conn_closed () = spec.conn_closed (io_id, conn_id) in
+    let handle () = handle_client ic oc (io_id, conn_id) spec in
+    let is_conn_closed _sleep_fn =
+      (* Without a sleep function we cannot safely loop waiting for EOF *)
+      match spec.sleep_fn with
+      | None -> fst (Lwt.task ()) (* wait to be cancelled *)
+      | Some sleep_fn ->
+          IO.wait_eof_or_closed io_id ic sleep_fn >>= fun () ->
+          Log.debug (fun m ->
+              m "Client closed the connection, got EOF for %s"
+                (Cohttp.Connection.to_string conn_id));
+          Lwt.return Call_conn_closed
+    in
     Lwt.catch
       (fun () ->
-        IO.catch (fun () -> handle_client ic oc (io_id, conn_id) spec)
+        IO.catch (fun () ->
+            Lwt.pick [ handle (); is_conn_closed spec.sleep_fn ] >>= function
+            | Call_conn_closed ->
+                conn_closed ();
+                Lwt.return_unit
+            | Call_conn_closed_and_drain body ->
+                conn_closed ();
+                Body.drain_body body >>= fun () -> Lwt.return_unit)
         >>= function
         | Ok () -> Lwt.return_unit
         | Error e ->

--- a/cohttp-mirage/src/io.ml
+++ b/cohttp-mirage/src/io.ml
@@ -76,4 +76,6 @@ module Make (Channel : Mirage_channel.S) = struct
       | Read_exn e -> Lwt.return_error (Read_error e)
       | Write_exn e -> Lwt.return_error (Write_error e)
       | ex -> Lwt.fail ex)
+
+  let wait_eof_or_closed _conn _ic _sleep_f = Lwt.return_unit
 end


### PR DESCRIPTION
MOTIVATION:
This is the place where we want to create the "clean" solution for the EOF and close_fn() issues that were found in the leak investigation.

PEOPLE INVOLVED:
The work has been done together by the people involved in this PR review:

@savvadia
@vect0r-vicall
@picojulien
(plus other people, which I do not know their GitHub names 😢 ):

Alistair
Raphael P.
PROCEDURE:
The first commit contains a "test_leak" test scenario, which is added to prove that the cohttp-lwt library is not behaving correspondingly in the following case:

First of all, run a make which will create our "test_leak" executable
Secondly, do a dune exec ./_build/default/cohttp-lwt-unix/test/test_leak.exe - this will create a server (running on port 8080, which will only accept calls to the sleep endpoint, which in turn continuously sleeps and prints a message every second.
Now, separately, call a curl request to that sleep endpoint - curl -s 'localhost:8080/sleep' - this will make the running server to print an "I slept" message every second.
When we close the connection from the client side (by CTRL+C - ing the curl command), we expect the connection with the server to be closed, but that is not the case, as we can see there is no "Server closed" message, as it should have been, according to the ~conn_closed argument of Server.make function from our "test_leak".
In the second commit, we introduce a change to the Cohttp_lwt.Server module, which fixes this behaviour, meaning that running the same procedure again will mean that the server does not print "I slept" anymore, but rather prints "Server closed".