### PR TITLE
Expose closefn function

### DIFF
--- a/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.ml
+++ b/cohttp-lwt-jsoo/src/cohttp_lwt_jsoo.ml
@@ -180,6 +180,9 @@ struct
 
   let callv ?ctx:_ _uri _reqs = Lwt.fail Cohttp_lwt_xhr_callv_not_implemented
 
+  let call_with_closefn ?ctx:_ ?headers:_ ?body:_ ?chunked:_ _meth _uri =
+    assert false
+
   (* ??? *)
 end
 

--- a/cohttp-lwt/src/s.ml
+++ b/cohttp-lwt/src/s.ml
@@ -74,7 +74,21 @@ module type Client = sig
       (using [ocaml-tls]) or SSL (using [ocaml-ssl]), on [*:443] or on the
       specified port by the user. If neitehr [ocaml-tls] or [ocaml-ssl] are
       installed on the system, [cohttp]/[conduit] tries the usual ([*:80]) or
-      the specified port by the user in a non-secured way. *)
+      the specified port by the user in a non-secured way.
+
+      The function returns response and body. *)
+
+  val call_with_closefn :
+    ?ctx:ctx ->
+    ?headers:Cohttp.Header.t ->
+    ?body:Body.t ->
+    ?chunked:bool ->
+    Cohttp.Code.meth ->
+    Uri.t ->
+    ((Cohttp.Response.t * Body.t) Lwt.t * (unit -> unit)) Lwt.t
+  (** [call_with_closefn ?ctx ?headers ?body ?chunked meth uri] is the same as
+      [call] but returns response, body and [close_fn] which force releases the
+      connection. *)
 
   val head :
     ?ctx:ctx -> ?headers:Cohttp.Header.t -> Uri.t -> Cohttp.Response.t Lwt.t


### PR DESCRIPTION
This work has been done together by the following people:
@savvadia
@vect0r-vicall
@picojulien
@johnyob
@raphael-proust

### Motivation

`cohttp` is not closing client-side connections on request in relay connections, which could lead to resource leak.
Exposing the `close_fn` function is already present in the newer `v6` version, so this addition we think is necessary as it allows finer resource management and is likely to be a backport of the feature from `v6` to `v5`.

### Solution

`cohttp` now exposes `close_fn` defined by `Cohttp_lwt.Client.call`. This callback should be used when a newly created connection should be closed, thanks to the new `Cohttp_lwt.Client.call_with_closefn` function.
